### PR TITLE
Bump MSBuild.StructuredLogger and fake-cli versions

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "5.20.2",
+      "version": "5.21.0-alpha004",
       "commands": [
         "fake"
       ]

--- a/paket.lock
+++ b/paket.lock
@@ -195,7 +195,7 @@ NUGET
       Fake.Core.Trace (>= 5.20.3) - restriction: >= netstandard2.0
       Fake.IO.FileSystem (>= 5.20.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-      MSBuild.StructuredLogger (>= 2.1.176) - restriction: >= netstandard2.0
+      MSBuild.StructuredLogger (>= 2.1.507) - restriction: >= netstandard2.0
     Fake.DotNet.NuGet (5.20.3) - restriction: >= netstandard2.0
       Fake.Core.Environment (>= 5.20.3) - restriction: >= netstandard2.0
       Fake.Core.Process (>= 5.20.3) - restriction: >= netstandard2.0
@@ -329,7 +329,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 5.0) - restriction: >= netcoreapp2.0
     Mono.Cecil (0.11.3) - restriction: >= netcoreapp2.0
     Mono.Posix.NETStandard (1.0) - restriction: >= netstandard2.0
-    MSBuild.StructuredLogger (2.1.215) - restriction: >= netstandard2.0
+    MSBuild.StructuredLogger (2.1.507) - restriction: >= netstandard2.0
       Microsoft.Build (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0


### PR DESCRIPTION
## Description

Fixes the build error `DotnetRestore 00:00:48.7167107 (Unsupported log file format. Latest supported version is 9, the log file has version 14.)` described in #1 by bumping the `MSBuild.StructuredLogger` and `fake-cli` versions.

## Changes

- Bump `MSBuild.StructuredLogger` version to `2.1.507`
- Bump `fake-cli` version to `5.21.0-alpha004`